### PR TITLE
Removing compilation gate requiring an Sql backend to be selected

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,9 +86,6 @@
 //! If you find database-specific features or documentation lacking,
 //! don't hesitate to open an issue/PR about it.
 
-#[cfg(not(any(feature = "sqlite3", feature = "pg", feature = "mysql")))]
-compile_error!("`barrel` cannot be built without a database backend specified");
-
 #[cfg(feature = "diesel")]
 pub mod integrations;
 #[cfg(feature = "diesel")]


### PR DESCRIPTION
Not entirely sure why this was added in the first place.
But I kinda feel this shouldn't be included anymore.

Potentially it will make debugging integrations harder but
who are we to tell people how to use the barrel type system?