### PR TITLE
Implementing table schemas

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -3,19 +3,20 @@
 //!
 //! It also re-exports the generators for existing databases
 //! so they can be used more conveniently.
-#[cfg(feature = "mysql")]
+
+// #[cfg(feature = "mysql")]
 mod mysql;
-#[cfg(feature = "mysql")]
+// #[cfg(feature = "mysql")]
 pub use self::mysql::MySql;
 
-#[cfg(feature = "pg")]
+// #[cfg(feature = "pg")]
 mod pg;
-#[cfg(feature = "pg")]
+// #[cfg(feature = "pg")]
 pub use self::pg::Pg;
 
-#[cfg(feature = "sqlite3")]
+// #[cfg(feature = "sqlite3")]
 mod sqlite3;
-#[cfg(feature = "sqlite3")]
+// #[cfg(feature = "sqlite3")]
 pub use self::sqlite3::Sqlite;
 
 #[allow(unused_imports)]
@@ -24,22 +25,22 @@ use crate::types::Type;
 /// A generic SQL generator trait
 pub trait SqlGenerator {
     /// Create a new table with a name
-    fn create_table(name: &str) -> String;
+    fn create_table(name: &str, schema: Option<&str>) -> String;
 
     /// Create a new table with a name, only if it doesn't exist
-    fn create_table_if_not_exists(name: &str) -> String;
+    fn create_table_if_not_exists(name: &str, schema: Option<&str>) -> String;
 
     /// Drop a table with a name
-    fn drop_table(name: &str) -> String;
+    fn drop_table(name: &str, schema: Option<&str>) -> String;
 
     /// Drop a table with a name, only if it exists
-    fn drop_table_if_exists(name: &str) -> String;
+    fn drop_table_if_exists(name: &str, schema: Option<&str>) -> String;
 
     /// Rename a table from <old> to <new>
-    fn rename_table(old: &str, new: &str) -> String;
+    fn rename_table(old: &str, new: &str, schema: Option<&str>) -> String;
 
     /// Modify a table in some other way
-    fn alter_table(name: &str) -> String;
+    fn alter_table(name: &str, schema: Option<&str>) -> String;
 
     /// Create a new column with a type
     fn add_column(ex: bool, name: &str, _type: &Type) -> String;

--- a/src/backend/mysql.rs
+++ b/src/backend/mysql.rs
@@ -6,31 +6,41 @@
 use super::SqlGenerator;
 use crate::types::{BaseType, Type};
 
+/// A simple macro that will generate a schema prefix if it exists
+macro_rules! prefix {
+    ($schema:expr) => {
+        $schema
+            .map(|s| format!("{}.", s))
+            .unwrap_or_else(|| String::new())
+    };
+}
+
 /// MySQL generator backend
 pub struct MySql;
 impl SqlGenerator for MySql {
-    fn create_table(name: &str) -> String {
-        format!("CREATE TABLE {}", name)
+    fn create_table(name: &str, schema: Option<&str>) -> String {
+        format!("CREATE TABLE {}{}", prefix!(schema), name)
     }
 
-    fn create_table_if_not_exists(name: &str) -> String {
-        format!("CREATE TABLE {} IF NOT EXISTS", name)
+    fn create_table_if_not_exists(name: &str, schema: Option<&str>) -> String {
+        format!("CREATE TABLE {}{} IF NOT EXISTS", prefix!(schema), name)
     }
 
-    fn drop_table(name: &str) -> String {
-        format!("DROP TABLE {}", name)
+    fn drop_table(name: &str, schema: Option<&str>) -> String {
+        format!("DROP TABLE {}{}", prefix!(schema), name)
     }
 
-    fn drop_table_if_exists(name: &str) -> String {
-        format!("DROP TABLE {} IF EXISTS", name)
+    fn drop_table_if_exists(name: &str, schema: Option<&str>) -> String {
+        format!("DROP TABLE {}{} IF EXISTS", prefix!(schema), name)
     }
 
-    fn rename_table(old: &str, new: &str) -> String {
-        format!("RENAME TABLE `{}` TO `{}`", old, new)
+    fn rename_table(old: &str, new: &str, schema: Option<&str>) -> String {
+        let schema = prefix!(schema);
+        format!("RENAME TABLE `{}{}` TO `{}{}`", schema, old, schema, new)
     }
 
-    fn alter_table(name: &str) -> String {
-        format!("ALTER TABLE `{}`", name)
+    fn alter_table(name: &str, schema: Option<&str>) -> String {
+        format!("ALTER TABLE `{}{}`", prefix!(schema), name)
     }
 
     fn add_column(ex: bool, name: &str, tt: &Type) -> String {

--- a/src/backend/pg.rs
+++ b/src/backend/pg.rs
@@ -6,31 +6,42 @@
 use super::SqlGenerator;
 use crate::types::{BaseType, Type};
 
+/// A simple macro that will generate a schema prefix if it exists
+macro_rules! prefix {
+    ($schema:expr) => {
+        $schema
+            .map(|s| format!("\"{}\".", s))
+            .unwrap_or_else(|| String::new())
+    };
+}
+
+
 /// Postgres SQL generator backend
 pub struct Pg;
 impl SqlGenerator for Pg {
-    fn create_table(name: &str) -> String {
-        format!("CREATE TABLE \"{}\"", name)
+    fn create_table(name: &str, schema: Option<&str>) -> String {
+        format!("CREATE TABLE {}\"{}\"", prefix!(schema), name)
     }
 
-    fn create_table_if_not_exists(name: &str) -> String {
-        format!("CREATE TABLE \"{}\" IF NOT EXISTS", name)
+    fn create_table_if_not_exists(name: &str, schema: Option<&str>) -> String {
+        format!("CREATE TABLE {}\"{}\" IF NOT EXISTS", prefix!(schema), name)
     }
 
-    fn drop_table(name: &str) -> String {
-        format!("DROP TABLE \"{}\"", name)
+    fn drop_table(name: &str, schema: Option<&str>) -> String {
+        format!("DROP TABLE {}\"{}\"", prefix!(schema), name)
     }
 
-    fn drop_table_if_exists(name: &str) -> String {
-        format!("DROP TABLE IF EXISTS \"{}\"", name)
+    fn drop_table_if_exists(name: &str, schema: Option<&str>) -> String {
+        format!("DROP TABLE IF EXISTS {}\"{}\"", prefix!(schema), name)
     }
 
-    fn rename_table(old: &str, new: &str) -> String {
-        format!("ALTER TABLE \"{}\" RENAME TO \"{}\"", old, new)
+    fn rename_table(old: &str, new: &str, schema: Option<&str>) -> String {
+        let schema = prefix!(schema);
+        format!("ALTER TABLE {}\"{}\" RENAME TO {}\"{}\"", schema, old, schema, new)
     }
 
-    fn alter_table(name: &str) -> String {
-        format!("ALTER TABLE \"{}\"", name)
+    fn alter_table(name: &str, schema: Option<&str>) -> String {
+        format!("ALTER TABLE {}\"{}\"", prefix!(schema), name)
     }
 
     fn add_column(ex: bool, name: &str, tt: &Type) -> String {

--- a/src/backend/sqlite3.rs
+++ b/src/backend/sqlite3.rs
@@ -3,32 +3,42 @@
 use super::SqlGenerator;
 use crate::types::{BaseType, Type};
 
+/// A simple macro that will generate a schema prefix if it exists
+macro_rules! prefix {
+    ($schema:expr) => {
+        $schema
+            .map(|s| format!("\"{}\".", s))
+            .unwrap_or_else(|| String::new())
+    };
+}
+
 /// We call this struct Sqlite instead of Sqlite3 because we hope not
 /// to have to break the API further down the road
 pub struct Sqlite;
 impl SqlGenerator for Sqlite {
-    fn create_table(name: &str) -> String {
-        format!("CREATE TABLE \"{}\"", name)
+    fn create_table(name: &str, schema: Option<&str>) -> String {
+        format!("CREATE TABLE {}\"{}\"", prefix!(schema), name)
     }
 
-    fn create_table_if_not_exists(name: &str) -> String {
-        format!("CREATE TABLE IF NOT EXISTS \"{}\"", name)
+    fn create_table_if_not_exists(name: &str, schema: Option<&str>) -> String {
+        format!("CREATE TABLE IF NOT EXISTS {}\"{}\"", prefix!(schema), name)
     }
 
-    fn drop_table(name: &str) -> String {
-        format!("DROP TABLE \"{}\"", name)
+    fn drop_table(name: &str, schema: Option<&str>) -> String {
+        format!("DROP TABLE {}\"{}\"", prefix!(schema), name)
     }
 
-    fn drop_table_if_exists(name: &str) -> String {
-        format!("DROP TABLE IF EXISTS \"{}\"", name)
+    fn drop_table_if_exists(name: &str, schema: Option<&str>) -> String {
+        format!("DROP TABLE IF EXISTS {}\"{}\"", prefix!(schema), name)
     }
 
-    fn rename_table(old: &str, new: &str) -> String {
-        format!("ALTER TABLE \"{}\" RENAME TO \"{}\"", old, new)
+    fn rename_table(old: &str, new: &str, schema: Option<&str>) -> String {
+        let schema = prefix!(schema);
+        format!("ALTER TABLE {}\"{}\" RENAME TO {}\"{}\"", schema, old, schema, new)
     }
 
-    fn alter_table(name: &str) -> String {
-        format!("ALTER TABLE \"{}\"", name)
+    fn alter_table(name: &str, schema: Option<&str>) -> String {
+        format!("ALTER TABLE {}\"{}\"", prefix!(schema), name)
     }
 
     fn add_column(ex: bool, name: &str, tt: &Type) -> String {

--- a/src/table.rs
+++ b/src/table.rs
@@ -61,7 +61,7 @@ impl Table {
             .push(TableChange::RenameColumn(old.into(), new.into()));
     }
 
-    pub fn make<T: SqlGenerator>(&mut self, ex: bool) -> Vec<String> {
+    pub fn make<T: SqlGenerator>(&mut self, ex: bool, schema: Option<&str>) -> Vec<String> {
         use TableChange::*;
         let mut s = Vec::new();
 
@@ -70,7 +70,7 @@ impl Table {
                 &mut AddColumn(ref name, ref col) => T::add_column(ex, name, &col),
                 &mut DropColumn(ref name) => T::drop_column(name),
                 &mut RenameColumn(ref old, ref new) => T::rename_column(old, new),
-                &mut ChangeColumn(ref mut name, _, _) => T::alter_table(name),
+                &mut ChangeColumn(ref mut name, _, _) => T::alter_table(name, schema),
             });
         }
 

--- a/src/tests/mysql/simple.rs
+++ b/src/tests/mysql/simple.rs
@@ -6,13 +6,19 @@ use crate::backend::{MySql, SqlGenerator};
 
 #[test]
 fn create_table() {
-    let sql = MySql::create_table("table_to_create");
+    let sql = MySql::create_table("table_to_create", None);
     assert_eq!(String::from("CREATE TABLE table_to_create"), sql);
 }
 
 #[test]
+fn create_table_with_schema() {
+    let sql = MySql::create_table("table_to_create", Some("my_schema"));
+    assert_eq!(String::from("CREATE TABLE my_schema.table_to_create"), sql);
+}
+
+#[test]
 fn create_table_if_not_exists() {
-    let sql = MySql::create_table_if_not_exists("table_to_create");
+    let sql = MySql::create_table_if_not_exists("table_to_create", None);
     assert_eq!(
         String::from("CREATE TABLE table_to_create IF NOT EXISTS"),
         sql
@@ -21,24 +27,24 @@ fn create_table_if_not_exists() {
 
 #[test]
 fn drop_table() {
-    let sql = MySql::drop_table("table_to_drop");
+    let sql = MySql::drop_table("table_to_drop", None);
     assert_eq!(String::from("DROP TABLE table_to_drop"), sql);
 }
 
 #[test]
 fn drop_table_if_exists() {
-    let sql = MySql::drop_table_if_exists("table_to_drop");
+    let sql = MySql::drop_table_if_exists("table_to_drop", None);
     assert_eq!(String::from("DROP TABLE table_to_drop IF EXISTS"), sql);
 }
 
 #[test]
 fn rename_table() {
-    let sql = MySql::rename_table("old_table", "new_table");
+    let sql = MySql::rename_table("old_table", "new_table", None);
     assert_eq!(String::from("RENAME TABLE `old_table` TO `new_table`"), sql);
 }
 
 #[test]
 fn alter_table() {
-    let sql = MySql::alter_table("table_to_alter");
+    let sql = MySql::alter_table("table_to_alter", None);
     assert_eq!(String::from("ALTER TABLE `table_to_alter`"), sql);
 }

--- a/src/tests/pg/simple.rs
+++ b/src/tests/pg/simple.rs
@@ -5,13 +5,19 @@ use crate::backend::{Pg, SqlGenerator};
 
 #[test]
 fn create_table() {
-    let sql = Pg::create_table("table_to_create");
+    let sql = Pg::create_table("table_to_create", None);
     assert_eq!(String::from("CREATE TABLE \"table_to_create\""), sql);
 }
 
 #[test]
+fn create_table_with_schema() {
+    let sql = Pg::create_table("table_to_create", Some("my_schema"));
+    assert_eq!(String::from("CREATE TABLE \"my_schema\".\"table_to_create\""), sql);
+}
+
+#[test]
 fn create_table_if_not_exists() {
-    let sql = Pg::create_table_if_not_exists("table_to_create");
+    let sql = Pg::create_table_if_not_exists("table_to_create", None);
     assert_eq!(
         String::from("CREATE TABLE \"table_to_create\" IF NOT EXISTS"),
         sql
@@ -20,19 +26,19 @@ fn create_table_if_not_exists() {
 
 #[test]
 fn drop_table() {
-    let sql = Pg::drop_table("table_to_drop");
+    let sql = Pg::drop_table("table_to_drop", None);
     assert_eq!(String::from("DROP TABLE \"table_to_drop\""), sql);
 }
 
 #[test]
 fn drop_table_if_exists() {
-    let sql = Pg::drop_table_if_exists("table_to_drop");
+    let sql = Pg::drop_table_if_exists("table_to_drop", None);
     assert_eq!(String::from("DROP TABLE IF EXISTS \"table_to_drop\""), sql);
 }
 
 #[test]
 fn rename_table() {
-    let sql = Pg::rename_table("old_table", "new_table");
+    let sql = Pg::rename_table("old_table", "new_table", None);
     assert_eq!(
         String::from("ALTER TABLE \"old_table\" RENAME TO \"new_table\""),
         sql
@@ -41,7 +47,7 @@ fn rename_table() {
 
 #[test]
 fn alter_table() {
-    let sql = Pg::alter_table("table_to_alter");
+    let sql = Pg::alter_table("table_to_alter", None);
     assert_eq!(String::from("ALTER TABLE \"table_to_alter\""), sql);
 }
 

--- a/src/tests/sqlite3/simple.rs
+++ b/src/tests/sqlite3/simple.rs
@@ -6,13 +6,19 @@ use crate::backend::{SqlGenerator, Sqlite};
 
 #[test]
 fn create_table() {
-    let sql = Sqlite::create_table("table_to_create");
+    let sql = Sqlite::create_table("table_to_create", None);
     assert_eq!(String::from("CREATE TABLE \"table_to_create\""), sql);
 }
 
 #[test]
+fn create_table_with_schema() {
+    let sql = Sqlite::create_table("table_to_create", Some("my_schema"));
+    assert_eq!(String::from("CREATE TABLE \"my_schema\".\"table_to_create\""), sql);
+}
+
+#[test]
 fn create_table_if_not_exists() {
-    let sql = Sqlite::create_table_if_not_exists("table_to_create");
+    let sql = Sqlite::create_table_if_not_exists("table_to_create", None);
     assert_eq!(
         String::from("CREATE TABLE IF NOT EXISTS \"table_to_create\""),
         sql
@@ -21,19 +27,19 @@ fn create_table_if_not_exists() {
 
 #[test]
 fn drop_table() {
-    let sql = Sqlite::drop_table("table_to_drop");
+    let sql = Sqlite::drop_table("table_to_drop", None);
     assert_eq!(String::from("DROP TABLE \"table_to_drop\""), sql);
 }
 
 #[test]
 fn drop_table_if_exists() {
-    let sql = Sqlite::drop_table_if_exists("table_to_drop");
+    let sql = Sqlite::drop_table_if_exists("table_to_drop", None);
     assert_eq!(String::from("DROP TABLE IF EXISTS \"table_to_drop\""), sql);
 }
 
 #[test]
 fn rename_table() {
-    let sql = Sqlite::rename_table("old_table", "new_table");
+    let sql = Sqlite::rename_table("old_table", "new_table", None);
     assert_eq!(
         String::from("ALTER TABLE \"old_table\" RENAME TO \"new_table\""),
         sql
@@ -42,6 +48,6 @@ fn rename_table() {
 
 #[test]
 fn alter_table() {
-    let sql = Sqlite::alter_table("table_to_alter");
+    let sql = Sqlite::alter_table("table_to_alter", None);
     assert_eq!(String::from("ALTER TABLE \"table_to_alter\""), sql);
 }


### PR DESCRIPTION
This PR adds the ability to prefix tables with a database schema.
The API has supported this feature for a _long_ time but for some
reason the feature was silently removed in a refactoring (woops).

Test coverage is still a bit lacking. This is adding a single test
for each backend to make sure it roughly works. And most importantly
tests that non-schema prefixed actions don't break existing tests :)