### PR TITLE
Adding `CustomLine` change to allow Sql injection into migrations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,9 @@ pub enum TableChange {
 
     /// Remove a column
     DropColumn(String),
+
+    /// Add some custom SQL
+    CustomLine(String),
 }
 
 /// An enum set that represents a single change on a database

--- a/src/table.rs
+++ b/src/table.rs
@@ -61,6 +61,10 @@ impl Table {
             .push(TableChange::RenameColumn(old.into(), new.into()));
     }
 
+    pub fn inject_custom<S: Into<String>>(&mut self, sql: S) {
+        self.changes.push(TableChange::CustomLine(sql.into()));
+    }
+
     pub fn make<T: SqlGenerator>(&mut self, ex: bool, schema: Option<&str>) -> Vec<String> {
         use TableChange::*;
 
@@ -71,6 +75,7 @@ impl Table {
                 &mut DropColumn(ref name) => T::drop_column(name),
                 &mut RenameColumn(ref old, ref new) => T::rename_column(old, new),
                 &mut ChangeColumn(ref mut name, _, _) => T::alter_table(name, schema),
+                &mut CustomLine(ref sql) => sql.clone()
             })
             .collect()
     }


### PR DESCRIPTION
This makes it possible to work around missing `barrel` features
without hitting a wall.