### PR TITLE
Initial `index` support (#63) fixes #54

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@
 [![](https://img.shields.io/crates/v/barrel.svg)](https://crates.io/crates/barrel)
 [![](https://img.shields.io/crates/d/barrel.svg)](https://crates.io/crates/barrel)
 
-A powerful schema migration builder, that let's you write your SQL migrations in Rust.
+A powerful database schema builder, that let's you write your SQL migrations in Rust!
 
-`barrel` makes writing migrations for different databases as easy as possible.
-It provides you with a common API over SQL,
-with certain features only provided for database specific implementations.
-This way you can focus on your Rust code, and stop worrying about SQL.
+`barrel` offers callback-style builder functions for SQL migrations
+and is designed to be flexible, portable and fun to use.
+It provides you with a common interface over SQL,
+with additional database-specific builders.
+
+This way you can focus on your Rust code, without having to worry about SQL.
 
 ## Example
 
@@ -20,17 +22,16 @@ The following example will help you get started
 
 ```rust
 use barrel::{types, Migration, Pg};
-use barrel::backend::Pg;
 
 fn main() {
     let mut m = Migration::new();
-    
+
     m.create_table("users", |t| {
         t.add_column("name", types::varchar(255));
         t.add_column("age", types::integer());
         t.add_column("owns_plushy_sharks", types::boolean());
     });
-    
+
     println!("{}", m.make::<Pg>());
 }
 ```
@@ -51,10 +52,6 @@ which then returns a `Type` enum.
 
 You can also directly created your own `Type` builders this way.
 Check the docs for details!
-
-## Unstable features
-
-Starting with `v0.2.4` `barrel` now has an `unstable` feature flag which will hide features and breaking changes that are in-development at the time of a minor or patch release. You can use these features if you so desire, but be aware that their usage will change more rapidely between versions (even patches) and their usage will be badly documented.
 
 ## License
 

--- a/examples/user_index.rs
+++ b/examples/user_index.rs
@@ -1,0 +1,18 @@
+
+use barrel::{Migration, types};
+
+fn main() {
+    let mut m = Migration::new();
+    m.create_table("users", |t| {
+        t.add_column("first_name", types::varchar(64).nullable(false));
+        t.add_column("last_name", types::varchar(64).nullable(false));
+        t.add_column("birthday", types::date().nullable(false));
+
+        t.add_index(
+            "names",
+            types::index(vec!["first_name", "last_name"])
+                .unique(true)
+                .nullable(false),
+        );
+    });
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -14,9 +14,9 @@ mod pg;
 #[cfg(feature = "pg")]
 pub use self::pg::Pg;
 
-#[cfg(feature = "sqlite3")]
+// #[cfg(feature = "sqlite3")]
 mod sqlite3;
-#[cfg(feature = "sqlite3")]
+// #[cfg(feature = "sqlite3")]
 pub use self::sqlite3::Sqlite;
 
 #[allow(unused_imports)]
@@ -24,7 +24,7 @@ use crate::{types::Type, Migration};
 
 /// An enum describing all supported Sql flavours
 pub enum SqlVariant {
-    #[cfg(feature = "sqlite3")]
+    // #[cfg(feature = "sqlite3")]
     Sqlite,
     #[cfg(feature = "pg")]
     Pg,
@@ -37,7 +37,7 @@ pub enum SqlVariant {
 impl SqlVariant {
     pub(crate) fn run_for(self, _migr: &Migration) -> String {
         match self {
-            #[cfg(feature = "sqlite3")]
+            // #[cfg(feature = "sqlite3")]
             SqlVariant::Sqlite => _migr.make::<Sqlite>(),
 
             #[cfg(feature = "pg")]
@@ -84,5 +84,5 @@ pub trait SqlGenerator {
     fn create_index(table: &str, schema: Option<&str>, name: &str, _type: &Type) -> String;
 
     /// Drop a multi-column index
-    fn drop_index(table: &str, schema: Option<&str>, name: &str) -> String;
+    fn drop_index(name: &str) -> String;
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -14,9 +14,9 @@ mod pg;
 #[cfg(feature = "pg")]
 pub use self::pg::Pg;
 
-// #[cfg(feature = "sqlite3")]
+#[cfg(feature = "sqlite3")]
 mod sqlite3;
-// #[cfg(feature = "sqlite3")]
+#[cfg(feature = "sqlite3")]
 pub use self::sqlite3::Sqlite;
 
 #[allow(unused_imports)]
@@ -24,7 +24,7 @@ use crate::{types::Type, Migration};
 
 /// An enum describing all supported Sql flavours
 pub enum SqlVariant {
-    // #[cfg(feature = "sqlite3")]
+    #[cfg(feature = "sqlite3")]
     Sqlite,
     #[cfg(feature = "pg")]
     Pg,
@@ -79,4 +79,10 @@ pub trait SqlGenerator {
 
     /// Rename an existing column
     fn rename_column(old: &str, new: &str) -> String;
+
+    /// Create a multi-column index
+    fn create_index(table: &str, schema: Option<&str>, name: &str, _type: &Type) -> String;
+
+    /// Drop a multi-column index
+    fn drop_index(table: &str, schema: Option<&str>, name: &str) -> String;
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -14,9 +14,9 @@ mod pg;
 #[cfg(feature = "pg")]
 pub use self::pg::Pg;
 
-// #[cfg(feature = "sqlite3")]
+#[cfg(feature = "sqlite3")]
 mod sqlite3;
-// #[cfg(feature = "sqlite3")]
+#[cfg(feature = "sqlite3")]
 pub use self::sqlite3::Sqlite;
 
 #[allow(unused_imports)]
@@ -24,7 +24,7 @@ use crate::{types::Type, Migration};
 
 /// An enum describing all supported Sql flavours
 pub enum SqlVariant {
-    // #[cfg(feature = "sqlite3")]
+    #[cfg(feature = "sqlite3")]
     Sqlite,
     #[cfg(feature = "pg")]
     Pg,
@@ -37,7 +37,7 @@ pub enum SqlVariant {
 impl SqlVariant {
     pub(crate) fn run_for(self, _migr: &Migration) -> String {
         match self {
-            // #[cfg(feature = "sqlite3")]
+            #[cfg(feature = "sqlite3")]
             SqlVariant::Sqlite => _migr.make::<Sqlite>(),
 
             #[cfg(feature = "pg")]

--- a/src/backend/pg.rs
+++ b/src/backend/pg.rs
@@ -89,7 +89,7 @@ impl SqlGenerator for Pg {
     fn create_index(table: &str, schema: Option<&str>, name: &str, _type: &Type) -> String {
         // FIXME: Implement PG specific index builder here
         format!(
-            "CREATE {} INDEX \"{}\" ON {}\"{}\" ({});",
+            "CREATE {} INDEX \"{}\" ON {}\"{}\" ({})",
             match _type.unique {
                 true => "UNIQUE",
                 false => "",

--- a/src/backend/pg.rs
+++ b/src/backend/pg.rs
@@ -64,7 +64,8 @@ impl SqlGenerator for Pg {
                 Binary => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt)),
                 Foreign(_) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt)),
                 Custom(_) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt)),
-                Array(it) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(Array(Box::new(*it))))
+                Array(it) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(Array(Box::new(*it)))),
+                Index(_) => unreachable!(), // Indices are handled via custom builder
             },
             match (&tt.default).as_ref() {
                 Some(ref m) => format!(" DEFAULT '{}'", m),
@@ -83,6 +84,32 @@ impl SqlGenerator for Pg {
 
     fn rename_column(old: &str, new: &str) -> String {
         format!("ALTER COLUMN \"{}\" RENAME TO \"{}\"", old, new)
+    }
+
+    fn create_index(table: &str, schema: Option<&str>, name: &str, _type: &Type) -> String {
+        // FIXME: Implement PG specific index builder here
+        format!(
+            "CREATE {} INDEX \"{}\" ON {}\"{}\" ({});",
+            match _type.unique {
+                true => "UNIQUE",
+                false => "",
+            },
+            name,
+            prefix!(schema),
+            table,
+            match _type.inner {
+                BaseType::Index(ref cols) => cols
+                    .iter()
+                    .map(|col| format!("\"{}\"", col))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                _ => unreachable!(),
+            }
+        )
+    }
+
+    fn drop_index(name: &str) -> String {
+        format!("DROP INDEX \"{}\"", name)
     }
 }
 
@@ -115,6 +142,7 @@ impl Pg {
             Foreign(t) => format!("INTEGER REFERENCES {}", t),
             Custom(t) => format!("{}", t),
             Array(meh) => format!("{}[]", Pg::print_type(*meh)),
+            Index(_) => unreachable!(), // Indices are handled via custom builder
         }
     }
 }

--- a/src/backend/sqlite3.rs
+++ b/src/backend/sqlite3.rs
@@ -62,7 +62,8 @@ impl SqlGenerator for Sqlite {
                 Binary => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
                 Foreign(_) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
                 Custom(_) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                Array(it) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(Array(Box::new(*it))))
+                Array(it) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(Array(Box::new(*it)))),
+                Index(_) => unimplemented!(),
             },
             match (&tt.default).as_ref() {
                 Some(ref m) => format!(" DEFAULT '{}'", m),
@@ -114,6 +115,7 @@ impl Sqlite {
             Foreign(t) => format!("INTEGER REFERENCES {}", t),
             Custom(t) => format!("{}", t),
             Array(meh) => format!("{}[]", Sqlite::print_type(*meh)),
+            Index(_) => unimplemented!(),
         }
     }
 }

--- a/src/backend/sqlite3.rs
+++ b/src/backend/sqlite3.rs
@@ -50,7 +50,8 @@ impl SqlGenerator for Sqlite {
 
         #[cfg_attr(rustfmt, rustfmt_skip)] /* This shouldn't be formatted. It's too long */
         format!(
-            "{}{}{}",
+            // SQL base - default - nullable - unique
+            "{}{}{}{}",
             match bt {
                 Text => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
                 Varchar(_) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
@@ -75,6 +76,10 @@ impl SqlGenerator for Sqlite {
             match tt.nullable {
                 true => "",
                 false => " NOT NULL",
+            },
+            match tt.unique {
+                true => " UNIQUE",
+                false => "",
             }
         )
     }
@@ -103,17 +108,15 @@ impl SqlGenerator for Sqlite {
 
     /// Drop a multi-column index
     fn drop_index(name: &str) -> String {
-        format!("DROP INDEX {}", name)
+        format!("DROP INDEX \"{}\"", name)
     }
 
-    #[allow(unused_variables)]
-    fn drop_column(name: &str) -> String {
-        unimplemented!()
+    fn drop_column(_: &str) -> String {
+        panic!("Sqlite does not support dropping columns!")
     }
 
-    #[allow(unused_variables)]
-    fn rename_column(old: &str, new: &str) -> String {
-        unimplemented!()
+    fn rename_column(_: &str, _: &str) -> String {
+        panic!("Sqlite does not support renaming columns!")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,9 +101,9 @@ pub mod migration;
 pub mod table;
 pub mod types;
 
+pub use backend::SqlVariant;
 pub use migration::Migration;
 pub use table::{Table, TableMeta};
-pub use backend::SqlVariant;
 
 #[cfg(test)]
 mod tests;
@@ -125,7 +125,7 @@ pub enum TableChange {
     /// Remove a column
     DropColumn(String),
 
-    /// Add some custom SQL
+    /// Add some custom SQL if all else fails
     CustomLine(String),
 }
 
@@ -149,4 +149,18 @@ pub enum DatabaseChange {
 
     /// Only drop a table if it exists
     DropTableIfExists(String),
+}
+
+/// An enum set that represents operations done with and on indices
+#[derive(Clone)]
+pub enum IndexChange {
+    /// Add a multi-column index
+    AddIndex {
+        index: String,
+        table: String,
+        columns: types::Type, // Should always be a `Index` type
+    },
+
+    /// Remove a multi-column index
+    RemoveIndex(String, String),
 }

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -60,7 +60,7 @@ impl Migration {
                 &mut CreateTable(ref mut t, ref mut cb)
                 | &mut CreateTableIfNotExists(ref mut t, ref mut cb) => {
                     cb(t); // Run the user code
-                    let (cols, _idxs) = t.make::<T>(false, schema);
+                    let (cols, indices) = t.make::<T>(false, schema);
 
                     let name = t.meta.name().clone();
                     sql.push_str(&match change {
@@ -82,7 +82,10 @@ impl Migration {
                     sql.push_str(")");
 
                     // Add additional index columns
-
+                    if indices.len() > 0 {
+                        sql.push_str(";");
+                        sql.push_str(&indices.join(";"));
+                    }
                 }
                 &mut DropTable(ref name) => sql.push_str(&T::drop_table(name, schema)),
                 &mut DropTableIfExists(ref name) => {
@@ -93,7 +96,7 @@ impl Migration {
                 }
                 &mut ChangeTable(ref mut t, ref mut cb) => {
                     cb(t);
-                    let (cols, _) = t.make::<T>(true, schema);
+                    let (cols, indices) = t.make::<T>(true, schema);
                     sql.push_str(&T::alter_table(&t.meta.name(), schema));
                     sql.push_str(" ");
                     let l = cols.len();
@@ -106,7 +109,10 @@ impl Migration {
                     }
 
                     // Add additional index columns
-
+                    if indices.len() > 0 {
+                        sql.push_str(";");
+                        sql.push_str(&indices.join(";"));
+                    }
                 },
             }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -131,7 +131,7 @@ impl Table {
                     table,
                     columns,
                 } => T::create_index(table, schema, index, columns),
-                IC::RemoveIndex(table, index) => T::drop_index(table, schema, index),
+                IC::RemoveIndex(_, index) => T::drop_index(index),
             })
             .collect();
 

--- a/src/tests/common/utils.rs
+++ b/src/tests/common/utils.rs
@@ -9,7 +9,7 @@ fn cloning_types() {
 #[test]
 fn debugging_types() {
     let tt = types::text();
-    assert_eq!(format!("{:#?}", tt), "Type {\n    nullable: false,\n    unique: false,\n    increments: false,\n    indexed: false,\n    default: None,\n    size: None,\n    inner: Text\n}".to_owned());
+    assert_eq!(format!("{:#?}", tt), "Type {\n    nullable: false,\n    unique: false,\n    increments: false,\n    indexed: false,\n    default: None,\n    size: None,\n    inner: Text,\n}".to_owned());
 }
 
 #[test]

--- a/src/types/builders.rs
+++ b/src/types/builders.rs
@@ -88,3 +88,9 @@ pub fn date() -> Type {
 pub fn array(inner: &Type) -> Type {
     Type::new(BaseType::Array(Box::new(inner.get_inner())))
 }
+
+/// Create an index over multiple, existing columns of the same type
+pub fn index<S: Into<String>>(columns: Vec<S>) -> Type {
+    let vec: Vec<String> = columns.into_iter().map(|s| s.into()).collect();
+    Type::new(BaseType::Index(vec))
+}

--- a/src/types/builders.rs
+++ b/src/types/builders.rs
@@ -13,8 +13,8 @@ pub fn primary() -> Type {
     Type::new(BaseType::Primary)
         .nullable(true) // Primary keys are non-null implicitly
         .increments(true)
-        .unique(true)
-        .indexed(true)
+        .unique(false) // Primary keys are unique implicitly
+        .indexed(false)
 }
 
 /// A (standardised) UUID primary key type

--- a/src/types/impls.rs
+++ b/src/types/impls.rs
@@ -34,6 +34,8 @@ pub enum BaseType {
     Custom(&'static str),
     /// Any of the above, but **many** of them
     Array(Box<BaseType>),
+    /// Indexing over multiple columns
+    Index(Vec<String>)
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -56,10 +58,10 @@ pub enum WrappedDefault<'outer> {
     Date(SystemTime),
     /// <inconceivable jibberish>
     Binary(&'outer [u8]),
-    // /// Foreign key to other table
-    // Foreign(Box<Type>),
+    /// Foreign key to other table
+    Foreign(Box<Type>),
     // I have no idea what you are – but I *like* it
-    // Custom(&'static str),
+    Custom(&'static str),
     /// Any of the above, but **many** of them
     Array(Vec<Type>),
 }
@@ -80,6 +82,8 @@ impl<'outer> Display for WrappedDefault<'outer> {
                 Boolean(ref val) => format!("{}", val),
                 Date(ref val) => format!("{:?}", val),
                 Binary(ref val) => format!("{:?}", val),
+                Foreign(ref val) => format!("{:?}", val),
+                Custom(ref val) => format!("{}", val),
                 Array(ref val) => format!("{:?}", val),
             }
         )
@@ -149,32 +153,32 @@ impl Type {
     pub(crate) fn get_inner(&self) -> BaseType {
         self.inner.clone()
     }
-    
+
     /// Set the nullability of this type
     pub fn nullable(self, arg: bool) -> Self {
         Self { nullable: arg, ..self }
     }
-    
+
     /// Set the uniqueness of this type
     pub fn unique(self, arg: bool) -> Self {
         Self { unique: arg, ..self }
     }
-    
+
     /// Specify if this type should auto-increment
     pub fn increments(self, arg: bool) -> Self {
         Self { increments: arg, ..self }
     }
-    
+
     /// Specify if this type should be indexed by your SQL implementation
     pub fn indexed(self, arg: bool) -> Self {
         Self { indexed: arg, ..self }
     }
-    
+
     /// Provide a default value for a type column
     pub fn default(self, arg: impl Into<WrappedDefault<'static>>) -> Self {
         Self { default: Some(arg.into()), ..self }
     }
-    
+
     /// Specify a size limit (important or varchar & similar)
     pub fn size(self, arg: usize) -> Self {
         Self { size: Some(arg), ..self }


### PR DESCRIPTION
This PR adds support for database indices. They are handled as part of the table constructor, although exist outside of the regular table changeset.

This is done to have an index change be scoped to a table (i.e. as far as I can tell, no database really supports multi-table indecies this way anyway), without having to match on changes when building a changeset.

An index addition is always handled on the same scope as creating a table.

The open tracking issue for this PR is #54 

##### Checklist

- [x] Basic API structure
- [x] Sqlite3 generation
- [x] Postgres generation
- [x] Mysql generation
- [ ] ~Document the use of `nullable(...)` for indices~ — superseded by #64 