### PR TITLE
Implementing "any primary key" feature and default redering

### DIFF
--- a/examples/sqlite_strings.rs
+++ b/examples/sqlite_strings.rs
@@ -4,8 +4,8 @@ use barrel::{types, Migration, Table};
 fn main() {
     let mut m = Migration::new();
     m.create_table("users", |t: &mut Table| {
-        t.add_column("id", types::primary());
-        t.add_column("name", types::varchar(255)); // Default name is "Anonymous"
+        t.add_column("id", types::text().primary(true));
+        t.add_column("name", types::varchar(255).default("Anonymous")); // Default name is "Anonymous"
         t.add_column("description", types::text().nullable(true)); // Can be null
         t.add_column("age", types::integer());
         t.add_column("posts", types::foreign("posts"));

--- a/src/backend/mysql.rs
+++ b/src/backend/mysql.rs
@@ -49,7 +49,7 @@ impl SqlGenerator for MySql {
 
         #[cfg_attr(rustfmt, rustfmt_skip)] /* This shouldn't be formatted. It's too long */
         format!(
-            "{}{}{}",
+            "{}{}{}{}",
             match bt {
                 Text => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt)),
                 Varchar(_) => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt)),
@@ -66,6 +66,10 @@ impl SqlGenerator for MySql {
                 Custom(_) => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt)),
                 Array(it) => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(Array(Box::new(*it)))),
                 Index(_) => unreachable!(),
+            },
+            match tt.primary {
+                true => " PRIMARY KEY",
+                false => "",
             },
             match (&tt.default).as_ref() {
                 Some(ref m) => format!(" DEFAULT '{}'", m),

--- a/src/backend/pg.rs
+++ b/src/backend/pg.rs
@@ -49,7 +49,7 @@ impl SqlGenerator for Pg {
 
         #[cfg_attr(rustfmt, rustfmt_skip)] /* This shouldn't be formatted. It's too long */
         format!(
-            "{}{}{}",
+            "{}{}{}{}",
             match bt {
                 Text => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt)),
                 Varchar(_) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt)),
@@ -66,6 +66,10 @@ impl SqlGenerator for Pg {
                 Custom(_) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt)),
                 Array(it) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(Array(Box::new(*it)))),
                 Index(_) => unreachable!(), // Indices are handled via custom builder
+            },
+            match tt.primary {
+                true => " PRIMARY KEY",
+                false => "",
             },
             match (&tt.default).as_ref() {
                 Some(ref m) => format!(" DEFAULT '{}'", m),

--- a/src/backend/sqlite3.rs
+++ b/src/backend/sqlite3.rs
@@ -51,7 +51,7 @@ impl SqlGenerator for Sqlite {
         #[cfg_attr(rustfmt, rustfmt_skip)] /* This shouldn't be formatted. It's too long */
         format!(
             // SQL base - default - nullable - unique
-            "{}{}{}{}",
+            "{}{}{}{}{}",
             match bt {
                 Text => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
                 Varchar(_) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
@@ -59,8 +59,8 @@ impl SqlGenerator for Sqlite {
                 Integer => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
                 Float => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
                 Double => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                UUID => unimplemented!(),
-                Json => unimplemented!(),
+                UUID => panic!("`UUID` not supported by Sqlite3. Use `Text` instead!"),
+                Json => panic!("`Json` not supported by Sqlite3. Use `Text` instead!"),
                 Boolean => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
                 Date => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
                 Binary => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
@@ -68,6 +68,10 @@ impl SqlGenerator for Sqlite {
                 Custom(_) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
                 Array(it) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(Array(Box::new(*it)))),
                 Index(_) => unreachable!(), // Indices are handled via custom builders
+            },
+            match tt.primary {
+                true => " PRIMARY KEY",
+                false => "",
             },
             match (&tt.default).as_ref() {
                 Some(ref m) => format!(" DEFAULT '{}'", m),
@@ -136,7 +140,7 @@ impl Sqlite {
                 0 => format!("VARCHAR"), // For "0" remove the limit
                 _ => format!("VARCHAR({})", l),
             },
-            Primary => format!("INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT"),
+            Primary => format!("INTEGER NOT NULL PRIMARY KEY"),
             Integer => format!("INTEGER"),
             Float => format!("REAL"),
             Double => format!("DOUBLE"),

--- a/src/tests/common/mod.rs
+++ b/src/tests/common/mod.rs
@@ -45,6 +45,7 @@ fn pin_struct_layout() {
     let tt = Type {
         nullable: false,
         indexed: false,
+        primary: false,
         unique: false,
         increments: false,
         default: None,
@@ -54,6 +55,7 @@ fn pin_struct_layout() {
 
     assert_eq!(tt.nullable, false);
     assert_eq!(tt.indexed, false);
+    assert_eq!(tt.primary, false);
     assert_eq!(tt.unique, false);
     assert_eq!(tt.increments, false);
     assert_eq!(tt.default, None);
@@ -62,15 +64,9 @@ fn pin_struct_layout() {
 }
 
 #[test]
-fn default_render_text() {
+fn default_render_anytext() {
     use self::WrappedDefault::*;
-    assert_eq!(format!("{}", Text("hello".into())), "hello".to_owned());
-}
-
-#[test]
-fn default_render_varchar() {
-    use self::WrappedDefault::*;
-    assert_eq!(format!("{}", Varchar("hello")), "hello".to_owned());
+    assert_eq!(format!("{}", AnyText("hello".into())), "hello".to_owned());
 }
 
 #[test]

--- a/src/tests/sqlite3/create_table.rs
+++ b/src/tests/sqlite3/create_table.rs
@@ -20,7 +20,7 @@ fn create_multiple_tables() {
         t.add_column("pic", types::text().nullable(true));
         t.add_column("mbid", types::text().nullable(true));
     });
-    assert_eq!(m.make::<Sqlite>(), String::from("CREATE TABLE \"artist\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"name\" TEXT, \"description\" TEXT, \"pic\" TEXT, \"mbid\" TEXT);CREATE TABLE \"album\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"name\" TEXT, \"pic\" TEXT, \"mbid\" TEXT);"));
+    assert_eq!(m.make::<Sqlite>(), String::from("CREATE TABLE \"artist\" (\"id\" INTEGER NOT NULL PRIMARY KEY, \"name\" TEXT, \"description\" TEXT, \"pic\" TEXT, \"mbid\" TEXT);CREATE TABLE \"album\" (\"id\" INTEGER NOT NULL PRIMARY KEY, \"name\" TEXT, \"pic\" TEXT, \"mbid\" TEXT);"));
 }
 
 #[test]
@@ -33,5 +33,5 @@ fn create_table_if_not_exists_doesnt_hit_unreachable() {
         t.add_column("pic", types::text().nullable(true));
         t.add_column("mbid", types::text().nullable(true));
     });
-    assert_eq!(m.make::<Sqlite>(), String::from("CREATE TABLE IF NOT EXISTS \"artist\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"name\" TEXT, \"description\" TEXT, \"pic\" TEXT, \"mbid\" TEXT);"));
+    assert_eq!(m.make::<Sqlite>(), String::from("CREATE TABLE IF NOT EXISTS \"artist\" (\"id\" INTEGER NOT NULL PRIMARY KEY, \"name\" TEXT, \"description\" TEXT, \"pic\" TEXT, \"mbid\" TEXT);"));
 }

--- a/src/types/builders.rs
+++ b/src/types/builders.rs
@@ -12,7 +12,8 @@ use crate::types::Type;
 pub fn primary() -> Type {
     Type::new(BaseType::Primary)
         .nullable(true) // Primary keys are non-null implicitly
-        .increments(true)
+        .increments(true) // This is ignored for now
+        .primary(false) // Primary keys are primary implictly
         .unique(false) // Primary keys are unique implicitly
         .indexed(false)
 }

--- a/src/types/defaults.rs
+++ b/src/types/defaults.rs
@@ -1,0 +1,90 @@
+
+use std::fmt::{self, Display, Formatter};
+use std::time::SystemTime;
+
+use super::Type;
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum WrappedDefault<'outer> {
+    /// Any text information
+    AnyText(&'outer str),
+    /// Simple integer
+    Integer(i64),
+    /// Floating point number
+    Float(f32),
+    /// Like Float but `~ ~ d o u b l e    p r e c i s i o n ~ ~`
+    Double(f64),
+    /// A unique identifier type
+    UUID(String), // TODO: Change to UUID type
+    /// True or False
+    Boolean(bool),
+    /// Date And Time
+    Date(SystemTime),
+    /// <inconceivable jibberish>
+    Binary(&'outer [u8]),
+    /// Foreign key to other table
+    Foreign(Box<Type>),
+    // I have no idea what you are – but I *like* it
+    Custom(&'static str),
+    /// Any of the above, but **many** of them
+    Array(Vec<Type>),
+}
+
+impl<'outer> Display for WrappedDefault<'outer> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        use self::WrappedDefault::*;
+        write!(
+            f,
+            "{}",
+            &match *self {
+                AnyText(ref val) => format!("{}", val),
+                Integer(ref val) => format!("{}", val),
+                Float(ref val) => format!("{}", val),
+                Double(ref val) => format!("{}", val),
+                UUID(ref val) => format!("{}", val),
+                Boolean(ref val) => format!("{}", val),
+                Date(ref val) => format!("{:?}", val),
+                Binary(ref val) => format!("{:?}", val),
+                Foreign(ref val) => format!("{:?}", val),
+                Custom(ref val) => format!("{}", val),
+                Array(ref val) => format!("{:?}", val),
+            }
+        )
+    }
+}
+
+impl From<&'static str> for WrappedDefault<'static> {
+    fn from(s: &'static str) -> Self {
+        WrappedDefault::AnyText(s)
+    }
+}
+
+impl From<i64> for WrappedDefault<'static> {
+    fn from(s: i64) -> Self {
+        WrappedDefault::Integer(s)
+    }
+}
+
+impl From<f32> for WrappedDefault<'static> {
+    fn from(s: f32) -> Self {
+        WrappedDefault::Float(s)
+    }
+}
+
+impl From<f64> for WrappedDefault<'static> {
+    fn from(s: f64) -> Self {
+        WrappedDefault::Double(s)
+    }
+}
+
+impl From<bool> for WrappedDefault<'static> {
+    fn from(s: bool) -> Self {
+        WrappedDefault::Boolean(s)
+    }
+}
+
+impl From<SystemTime> for WrappedDefault<'static> {
+    fn from(s: SystemTime) -> Self {
+        WrappedDefault::Date(s)
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2,9 +2,8 @@
 
 mod builders;
 mod impls;
+mod defaults;
 
-/// Export all builder functions
 pub use self::builders::*;
-
-/// Export only the Type struct
-pub use self::impls::{BaseType, Type, WrappedDefault};
+pub use self::impls::{BaseType, Type};
+pub use self::defaults::WrappedDefault;


### PR DESCRIPTION
This PR changes the way that the `types::primary()` builder works and
adds a `primary(bool)` function to the Type pattern. The `PRIMARY`
base type still exists, but is handled seperately, for Pg reasons
(should be removed next version).  All other types that use the
`primary(...)` function will be able to become `PRIMARY KEY` in the
generated SQL.

Additionally this PR fixes the way that `WrappedDefault` values are
encoded. i.e. it is now possible to properly specify a default value
that is then mapped into the apropriate type.