### PR TITLE
Fix issue with running `diesel migrations list`

### DIFF
--- a/src/integrations/diesel.rs
+++ b/src/integrations/diesel.rs
@@ -119,7 +119,7 @@ version = \"0.0.0\"
 authors = [\"Katharina Fey <kookie@spacekookie.de>\"]
 # TODO: Use same `barrel` dependency as crate
 [dependencies]
-barrel = {{ version = \"*\", features = [ {} ] }}",
+barrel = {{ version = \"*\", features = [ {:?} ] }}",
         feat
     );
 


### PR DESCRIPTION
The tmp package wouldn't build because the feature specified by the
backend wasn't properly wrapped in quotes. Cargo would complain about
parsing the `Cargo.toml` file.

The error that would be returned is:

```
thread 'main' panicked at 'index out of bounds: the len is 1 but the index is 1', /rustc/5eeb567a27eba18420a620ca7d0c007e29d8bc0c/src/libcore/slice/mod.rs:2695:10
```

This happened because the tmp package was never built since it failed in parsing the `Cargo.toml` file.