### PR TITLE
Fix index creation for MySQL and SQLite

### DIFF
--- a/src/backend/mysql.rs
+++ b/src/backend/mysql.rs
@@ -93,9 +93,9 @@ impl SqlGenerator for MySql {
     fn create_index(table: &str, schema: Option<&str>, name: &str, _type: &Type) -> String {
         // FIXME: Implement Mysql specific index builder here
         format!(
-            "CREATE {}INDEX {} ON {}{} ({})",
+            "CREATE {} INDEX {} ON {}{} ({})",
             match _type.unique {
-                true => "UNIQUE ",
+                true => "UNIQUE",
                 false => "",
             },
             name,

--- a/src/backend/mysql.rs
+++ b/src/backend/mysql.rs
@@ -93,9 +93,9 @@ impl SqlGenerator for MySql {
     fn create_index(table: &str, schema: Option<&str>, name: &str, _type: &Type) -> String {
         // FIXME: Implement Mysql specific index builder here
         format!(
-            "CREATE {} INDEX \"{}\" ON {}\"{}\" ({})",
+            "CREATE {}INDEX {} ON {}{} ({})",
             match _type.unique {
-                true => "UNIQUE",
+                true => "UNIQUE ",
                 false => "",
             },
             name,
@@ -104,7 +104,7 @@ impl SqlGenerator for MySql {
             match _type.inner {
                 BaseType::Index(ref cols) => cols
                     .iter()
-                    .map(|col| format!("\"{}\"", col))
+                    .map(|col| format!("{}", col))
                     .collect::<Vec<_>>()
                     .join(", "),
                 _ => unreachable!(),

--- a/src/backend/pg.rs
+++ b/src/backend/pg.rs
@@ -96,9 +96,9 @@ impl SqlGenerator for Pg {
     fn create_index(table: &str, schema: Option<&str>, name: &str, _type: &Type) -> String {
         // FIXME: Implement PG specific index builder here
         format!(
-            "CREATE {} INDEX \"{}\" ON {}\"{}\" ({})",
+            "CREATE {}INDEX \"{}\" ON {}\"{}\" ({})",
             match _type.unique {
-                true => "UNIQUE",
+                true => "UNIQUE ",
                 false => "",
             },
             name,

--- a/src/backend/pg.rs
+++ b/src/backend/pg.rs
@@ -96,9 +96,9 @@ impl SqlGenerator for Pg {
     fn create_index(table: &str, schema: Option<&str>, name: &str, _type: &Type) -> String {
         // FIXME: Implement PG specific index builder here
         format!(
-            "CREATE {}INDEX \"{}\" ON {}\"{}\" ({})",
+            "CREATE {} INDEX \"{}\" ON {}\"{}\" ({})",
             match _type.unique {
-                true => "UNIQUE ",
+                true => "UNIQUE",
                 false => "",
             },
             name,

--- a/src/backend/sqlite3.rs
+++ b/src/backend/sqlite3.rs
@@ -88,13 +88,13 @@ impl SqlGenerator for Sqlite {
     /// Create a multi-column index
     fn create_index(table: &str, schema: Option<&str>, name: &str, _type: &Type) -> String {
         format!(
-            "CREATE {} INDEX \"{}\" ON {}\"{}\" ({});",
+            "CREATE {} INDEX {}\"{}\" ON \"{}\" ({});",
             match _type.unique {
                 true => "UNIQUE",
                 false => "",
             },
-            name,
             prefix!(schema),
+            name,
             table,
             match _type.inner {
                 BaseType::Index(ref cols) => cols


### PR DESCRIPTION
During my work for Prisma, I saw that index creation through Barrel didn't work for MySQL and SQLite. This PR rectifies that.