### PR TITLE
Include MySQL add_column tests

### DIFF
--- a/src/tests/mysql/add_column.rs
+++ b/src/tests/mysql/add_column.rs
@@ -7,14 +7,14 @@ use crate::types;
 #[test]
 fn text() {
     let sql = MySql::add_column(true, "Text", &types::text());
-    assert_eq!(String::from("ADD COLUMN \"Text\" TEXT NOT NULL"), sql);
+    assert_eq!(String::from("ADD COLUMN Text TEXT NOT NULL"), sql);
 }
 
 #[test]
 fn varchar() {
     let sql = MySql::add_column(true, "Varchar", &types::varchar(255));
     assert_eq!(
-        String::from("ADD COLUMN \"Varchar\" VARCHAR(255) NOT NULL"),
+        String::from("ADD COLUMN Varchar VARCHAR(255) NOT NULL"),
         sql
     );
 }
@@ -22,53 +22,44 @@ fn varchar() {
 #[test]
 fn integer() {
     let sql = MySql::add_column(true, "Integer", &types::integer());
-    assert_eq!(String::from("ADD COLUMN \"Integer\" INTEGER NOT NULL"), sql);
+    assert_eq!(String::from("ADD COLUMN Integer INTEGER NOT NULL"), sql);
 }
 
 #[test]
 fn float() {
     let sql = MySql::add_column(true, "Float", &types::float());
-    assert_eq!(String::from("ADD COLUMN \"Float\" FLOAT NOT NULL"), sql);
+    assert_eq!(String::from("ADD COLUMN Float FLOAT NOT NULL"), sql);
 }
 
 #[test]
 fn double() {
     let sql = MySql::add_column(true, "Double", &types::double());
-    assert_eq!(String::from("ADD COLUMN \"Double\" DOUBLE PRECISION NOT NULL"), sql);
+    assert_eq!(String::from("ADD COLUMN Double DOUBLE NOT NULL"), sql);
 }
 
 #[test]
 fn boolean() {
     let sql = MySql::add_column(true, "Boolean", &types::boolean());
-    assert_eq!(String::from("ADD COLUMN \"Boolean\" BOOLEAN NOT NULL"), sql);
+    assert_eq!(String::from("ADD COLUMN Boolean BOOLEAN NOT NULL"), sql);
 }
 
 #[test]
 fn binary() {
     let sql = MySql::add_column(true, "Binary", &types::binary());
-    assert_eq!(String::from("ADD COLUMN \"Binary\" BYTEA NOT NULL"), sql);
+    assert_eq!(String::from("ADD COLUMN Binary BYTEA NOT NULL"), sql);
 }
 
 #[test]
 fn date() {
     let sql = MySql::add_column(true, "Date", &types::date());
-    assert_eq!(String::from("ADD COLUMN \"Date\" DATE NOT NULL"), sql);
+    assert_eq!(String::from("ADD COLUMN Date DATE NOT NULL"), sql);
 }
 
 #[test]
 fn foreign() {
     let sql = MySql::add_column(true, "Foreign", &types::foreign("posts"));
     assert_eq!(
-        String::from("ADD COLUMN \"Foreign\" INTEGER REFERENCES posts NOT NULL"),
-        sql
-    );
-}
-
-#[test]
-fn uuid() {
-    let sql = MySql::add_column(true, "MyUUID", &types::uuid());
-    assert_eq!(
-        String::from("ADD COLUMN Foreign CHAR(36)"),
+        String::from("ADD COLUMN Foreign INTEGER REFERENCES posts NOT NULL"),
         sql
     );
 }

--- a/src/tests/mysql/add_column.rs
+++ b/src/tests/mysql/add_column.rs
@@ -1,8 +1,8 @@
-//! All add_column combinations for pgsql
+//! All add_column combinations for mysql
 #![allow(unused_imports)]
 
-use backend::{MySql, SqlGenerator};
-use types;
+use crate::backend::{MySql, SqlGenerator};
+use crate::types;
 
 #[test]
 fn text() {
@@ -66,7 +66,7 @@ fn foreign() {
 
 #[test]
 fn uuid() {
-    let sql = MySql::add_column(true, "MyUUID", &types::UUID);
+    let sql = MySql::add_column(true, "MyUUID", &types::uuid());
     assert_eq!(
         String::from("ADD COLUMN Foreign CHAR(36)"),
         sql

--- a/src/tests/mysql/mod.rs
+++ b/src/tests/mysql/mod.rs
@@ -1,4 +1,5 @@
-//! A few simple tests for the sqlite3 string backend
+//! Test mysql generation
 
+mod add_column;
 mod create_table;
 mod simple;


### PR DESCRIPTION
This is about the comment I've made in issue https://github.com/rust-db/barrel/issues/8#issuecomment-522310606.

In **summary**, the tests in tests/mysql/add_column.rs aren't run because they're not in tests/mysql/mod.rs. This change includes the add_column tests.

The changes are grouped into 2 commits:

1. Fixing compile errors
2. Fixing test failures

Detailed description of the changes are included in the commit messages.

Please let me know if you have any suggestions to improve this PR.
