### PR TITLE
Replace tempdir with tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ required-features = ["sqlite3"]
 
 [features]
 default = []
-diesel = ["tempdir", "diesel_rs"]
+diesel = ["tempfile", "diesel_rs"]
 sqlite3 = []
 mysql = []
 pg = []
@@ -36,7 +36,7 @@ unstable = []
 
 
 [dependencies]
-tempdir = { version = "0.3.4", optional = true }
+tempfile = { version = "3", optional = true }
 diesel_rs = { version = ">= 1.2, < 2.0", package = "diesel", default_features = false, optional = true }
 
 [package.metadata.docs.rs]

--- a/src/integrations/diesel.rs
+++ b/src/integrations/diesel.rs
@@ -103,9 +103,9 @@ fn run_barrel_migration_wrapper(path: &Path) -> Box<Migration> {
 
 fn run_barrel_migration(migration: &Path) -> (String, String) {
     /* Create a tmp dir with src/ child */
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
-    let dir = TempDir::new("barrel").unwrap();
+    let dir = Builder::new().prefix("barrel").tempdir().unwrap();
     fs::create_dir_all(&dir.path().join("src")).unwrap();
 
     let (feat, ident) = get_backend_pair();


### PR DESCRIPTION
`tempdir` has been deprecated after being merged into `tempfile`