### PR TITLE
Do not quote default values for Pg backend

### DIFF
--- a/src/backend/pg.rs
+++ b/src/backend/pg.rs
@@ -75,7 +75,7 @@ impl SqlGenerator for Pg {
                 false => "",
             },
             match (&tt.default).as_ref() {
-                Some(ref m) => format!(" DEFAULT '{}'", m),
+                Some(ref m) => format!(" DEFAULT {}", m),
                 _ => format!(""),
             },
             match tt.nullable {


### PR DESCRIPTION
Single-quoting the value makes it impossible to use functions.

Instead, the quoting should happen in the parameter to `default()`.

This should also close #99.