### PR TITLE
Use correct syntax for `CREATE TABLE IF NOT EXISTS` and `DROP TABLE IF EXISTS` in MySql backend

### DIFF
--- a/src/backend/mysql.rs
+++ b/src/backend/mysql.rs
@@ -23,7 +23,7 @@ impl SqlGenerator for MySql {
     }
 
     fn create_table_if_not_exists(name: &str, schema: Option<&str>) -> String {
-        format!("CREATE TABLE {}`{}` IF NOT EXISTS", prefix!(schema), name)
+        format!("CREATE TABLE IF NOT EXISTS {}`{}`", prefix!(schema), name)
     }
 
     fn drop_table(name: &str, schema: Option<&str>) -> String {
@@ -31,7 +31,7 @@ impl SqlGenerator for MySql {
     }
 
     fn drop_table_if_exists(name: &str, schema: Option<&str>) -> String {
-        format!("DROP TABLE {}`{}` IF EXISTS", prefix!(schema), name)
+        format!("DROP TABLE IF EXISTS {}`{}`", prefix!(schema), name)
     }
 
     fn rename_table(old: &str, new: &str, schema: Option<&str>) -> String {

--- a/src/tests/mysql/create_table.rs
+++ b/src/tests/mysql/create_table.rs
@@ -33,5 +33,5 @@ fn create_table_if_not_exists_doesnt_hit_unreachable() {
         t.add_column("pic", types::text().nullable(true));
         t.add_column("mbid", types::text().nullable(true));
     });
-    assert_eq!(m.make::<MySql>(), String::from("CREATE TABLE `artist` IF NOT EXISTS (`id` INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY, `name` TEXT, `description` TEXT, `pic` TEXT, `mbid` TEXT);"));
+    assert_eq!(m.make::<MySql>(), String::from("CREATE TABLE IF NOT EXISTS `artist` (`id` INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY, `name` TEXT, `description` TEXT, `pic` TEXT, `mbid` TEXT);"));
 }

--- a/src/tests/mysql/simple.rs
+++ b/src/tests/mysql/simple.rs
@@ -20,7 +20,7 @@ fn create_table_with_schema() {
 fn create_table_if_not_exists() {
     let sql = MySql::create_table_if_not_exists("table_to_create", None);
     assert_eq!(
-        String::from("CREATE TABLE `table_to_create` IF NOT EXISTS"),
+        String::from("CREATE TABLE IF NOT EXISTS `table_to_create`"),
         sql
     );
 }
@@ -34,7 +34,7 @@ fn drop_table() {
 #[test]
 fn drop_table_if_exists() {
     let sql = MySql::drop_table_if_exists("table_to_drop", None);
-    assert_eq!(String::from("DROP TABLE `table_to_drop` IF EXISTS"), sql);
+    assert_eq!(String::from("DROP TABLE IF EXISTS `table_to_drop`"), sql);
 }
 
 #[test]


### PR DESCRIPTION
In MySql the table name is placed after `IF`, not before:

```sql
CREATE TABLE IF NOT EXISTS `snippet` (`id` INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY);
DROP TABLE IF EXISTS `snippet`;
```