### PR TITLE
Resolve a test warning because of a typo.

### DIFF
--- a/src/types/impls.rs
+++ b/src/types/impls.rs
@@ -92,7 +92,7 @@ pub enum BaseType {
 ///
 /// ## Examples
 ///
-/// ```rust,norun
+/// ```rust,no_run
 /// extern crate barrel;
 /// use barrel::types::*;
 ///


### PR DESCRIPTION
warning: unknown attribute `norun`. Did you mean `no_run`?