### PR TITLE
Support ON UPDATE and ON DELETE statements, updated Foreign type.

### DIFF
--- a/examples/sqlite_strings.rs
+++ b/examples/sqlite_strings.rs
@@ -8,7 +8,15 @@ fn main() {
         t.add_column("name", types::varchar(255).default("Anonymous")); // Default name is "Anonymous"
         t.add_column("description", types::text().nullable(true)); // Can be null
         t.add_column("age", types::integer());
-        t.add_column("posts", types::foreign("posts", "id"));
+        t.add_column(
+            "posts",
+            types::foreign(
+                "posts",
+                "id",
+                types::ReferentialAction::Unset,
+                types::ReferentialAction::Unset,
+            ),
+        );
         t.add_column("created_at", types::date());
         t.add_column("owns_plushy_sharks", types::boolean());
     });

--- a/src/backend/mysql.rs
+++ b/src/backend/mysql.rs
@@ -48,62 +48,78 @@ impl SqlGenerator for MySql {
 
     fn add_column(ex: bool, schema: Option<&str>, name: &str, tt: &Type) -> String {
         let bt: BaseType = tt.get_inner();
+        let btc = bt.clone();
         use self::BaseType::*;
         let name = format!("`{}`", name);
-
+        let nullable_definition = match tt.nullable {
+            true => "",
+            false => " NOT NULL",
+        };
+        let unique_definition = match tt.unique {
+            true => " UNIQUE",
+            false => "",
+        };
+        let primary_definition = match tt.primary {
+            true => " PRIMARY KEY",
+            false => "",
+        };
         #[cfg_attr(rustfmt, rustfmt_skip)] /* This shouldn't be formatted. It's too long */
-        format!(
-            "{}{}{}{}{}",
-            match bt {
-                Text => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
-                Varchar(_) => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
-                Char(_) => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
-                Primary => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
-                Integer => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
-                Serial => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
-                Float => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
-                Double => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
+        let base_type_definition = match bt {
+                Text => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+                Varchar(_) => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+                Char(_) => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+                Primary => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+                Integer => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+                Serial => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+                Float => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+                Double => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
                 UUID => unimplemented!(),
-                Json => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
-                Boolean => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
-                Date => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
-                Time => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
-                DateTime => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
-                Binary => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
-                Foreign(_, _, _, _, _) => format!("{}{} INTEGER, FOREIGN KEY ({}) {}", MySql::prefix(ex), name, name, MySql::print_type(bt, schema)),
-                Custom(_) => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(bt, schema)),
-                Array(it) => format!("{}{} {}", MySql::prefix(ex), name, MySql::print_type(Array(Box::new(*it)), schema)),
+                Json => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+                Boolean => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+                Date => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+                Time => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+                DateTime => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+                Binary => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+                Foreign(_, _, _, _, _) => format!("{}{} INTEGER{}, FOREIGN KEY ({}) {}", Self::prefix(ex), name, nullable_definition, name, Self::print_type(bt, schema)),
+                Custom(_) => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+                Array(it) => format!("{}{} {}", Self::prefix(ex), name, Self::print_type(Array(Box::new(*it)), schema)),
                 Index(_) => unreachable!("Indices are handled via custom builder"),
                 Constraint(_, _) => unreachable!("Constraints are handled via custom builder"),
-            },
-            match tt.primary {
-                true => " PRIMARY KEY",
-                false => "",
-            },
-            match (&tt.default).as_ref() {
-                Some(ref m) => match m {
-                    WrappedDefault::Function(ref fun) => match fun {
-                        AutogenFunction::CurrentTimestamp => format!(" DEFAULT CURRENT_TIMESTAMP")
-                    },
-                    WrappedDefault::Null => format!(" DEFAULT NULL"),
-                    WrappedDefault::AnyText(ref val) => format!(" DEFAULT '{}'", val),
-                    WrappedDefault::UUID(ref val) => format!(" DEFAULT '{}'", val),
-                    WrappedDefault::Date(ref val) => format!(" DEFAULT '{:?}'", val),
-                    WrappedDefault::Boolean(val) => format!(" DEFAULT {}", if *val { 1 } else { 0 }),
-                    WrappedDefault::Custom(ref val) => format!(" DEFAULT '{}'", val),
-                    _ => format!(" DEFAULT {}", m),
+            };
+        let default_definition = match (&tt.default).as_ref() {
+            Some(ref m) => match m {
+                WrappedDefault::Function(ref fun) => match fun {
+                    AutogenFunction::CurrentTimestamp => format!(" DEFAULT CURRENT_TIMESTAMP"),
                 },
-                _ => format!(""),
+                WrappedDefault::Null => format!(" DEFAULT NULL"),
+                WrappedDefault::AnyText(ref val) => format!(" DEFAULT '{}'", val),
+                WrappedDefault::UUID(ref val) => format!(" DEFAULT '{}'", val),
+                WrappedDefault::Date(ref val) => format!(" DEFAULT '{:?}'", val),
+                WrappedDefault::Boolean(val) => format!(" DEFAULT {}", if *val { 1 } else { 0 }),
+                WrappedDefault::Custom(ref val) => format!(" DEFAULT '{}'", val),
+                _ => format!(" DEFAULT {}", m),
             },
-            match tt.nullable {
-                true => "",
-                false => " NOT NULL",
-            },
-            match tt.unique {
-                true => " UNIQUE",
-                false => "",
-            },
-        )
+            _ => format!(""),
+        };
+
+        match btc {
+            Foreign(_, _, _, _, _) => {
+                format!(
+                    "{}{}{}{}",
+                    base_type_definition, primary_definition, default_definition, unique_definition,
+                )
+            }
+            _ => {
+                format!(
+                    "{}{}{}{}{}",
+                    base_type_definition,
+                    primary_definition,
+                    default_definition,
+                    nullable_definition,
+                    unique_definition,
+                )
+            }
+        }
     }
 
     fn drop_column(name: &str) -> String {

--- a/src/backend/pg.rs
+++ b/src/backend/pg.rs
@@ -51,60 +51,76 @@ impl SqlGenerator for Pg {
 
     fn add_column(ex: bool, schema: Option<&str>, name: &str, tt: &Type) -> String {
         let bt: BaseType = tt.get_inner();
+        let btc = bt.clone();
         use self::BaseType::*;
-
-        #[cfg_attr(rustfmt, rustfmt_skip)] /* This shouldn't be formatted. It's too long */
-        format!(
-            "{}{}{}{}{}",
-            match bt {
-                Text => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                Varchar(_) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                Char(_) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                Primary => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                Integer => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                Serial => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                Float => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                Double => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                UUID => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                Json => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                Boolean => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                Date => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                Time => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                DateTime => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                Binary => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                Foreign(_, _, _, _, _) => format!("{}\"{}\" INTEGER, FOREIGN KEY ({}) {}", Pg::prefix(ex), name, name, Pg::print_type(bt, schema)),
-                Custom(_) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(bt, schema)),
-                Array(it) => format!("{}\"{}\" {}", Pg::prefix(ex), name, Pg::print_type(Array(Box::new(*it)), schema)),
-                Index(_) => unreachable!("Indices are handled via custom builder"),
-                Constraint(_, _) => unreachable!("Constraints are handled via custom builder"),
-            },
-            match tt.primary {
-                true => " PRIMARY KEY",
-                false => "",
-            },
-            match (&tt.default).as_ref() {
-                Some(ref m) => match m {
-                    WrappedDefault::Function(ref fun) => match fun {
-                        AutogenFunction::CurrentTimestamp => format!(" DEFAULT CURRENT_TIMESTAMP")
-                    }
-                    WrappedDefault::Null => format!(" DEFAULT NULL"),
-                    WrappedDefault::AnyText(ref val) => format!(" DEFAULT '{}'", val),
-                    WrappedDefault::UUID(ref val) => format!(" DEFAULT '{}'", val),
-                    WrappedDefault::Date(ref val) => format!(" DEFAULT '{:?}'", val),
-                    WrappedDefault::Custom(ref val) => format!(" DEFAULT '{}'", val),
-                    _ => format!(" DEFAULT {}", m)
+        let primary_definition = match tt.primary {
+            true => " PRIMARY KEY",
+            false => "",
+        };
+        let default_definition = match (&tt.default).as_ref() {
+            Some(ref m) => match m {
+                WrappedDefault::Function(ref fun) => match fun {
+                    AutogenFunction::CurrentTimestamp => format!(" DEFAULT CURRENT_TIMESTAMP"),
                 },
-                _ => format!(""),
+                WrappedDefault::Null => format!(" DEFAULT NULL"),
+                WrappedDefault::AnyText(ref val) => format!(" DEFAULT '{}'", val),
+                WrappedDefault::UUID(ref val) => format!(" DEFAULT '{}'", val),
+                WrappedDefault::Date(ref val) => format!(" DEFAULT '{:?}'", val),
+                WrappedDefault::Custom(ref val) => format!(" DEFAULT '{}'", val),
+                _ => format!(" DEFAULT {}", m),
             },
-            match tt.nullable {
-                true => "",
-                false => " NOT NULL",
-            },
-            match tt.unique {
-                true => " UNIQUE",
-                false => "",
-            },
-        )
+            _ => format!(""),
+        };
+        let nullable_definition = match tt.nullable {
+            true => "",
+            false => " NOT NULL",
+        };
+        let unique_definition = match tt.unique {
+            true => " UNIQUE",
+            false => "",
+        };
+        #[cfg_attr(rustfmt, rustfmt_skip)] /* This shouldn't be formatted. It's too long */
+        let base_type_definition = match bt {
+            Text => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            Varchar(_) => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            Char(_) => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            Primary => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            Integer => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            Serial => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            Float => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            Double => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            UUID => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            Json => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            Boolean => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            Date => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            Time => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            DateTime => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            Binary => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            Foreign(_, _, _, _, _) => format!("{}\"{}\" INTEGER{}, FOREIGN KEY ({}) {}", Self::prefix(ex), name, nullable_definition, name, Self::print_type(bt, schema)),
+            Custom(_) => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(bt, schema)),
+            Array(it) => format!("{}\"{}\" {}", Self::prefix(ex), name, Self::print_type(Array(Box::new(*it)), schema)),
+            Index(_) => unreachable!("Indices are handled via custom builder"),
+            Constraint(_, _) => unreachable!("Constraints are handled via custom builder"),
+        };
+
+        match btc {
+            Foreign(_, _, _, _, _) => {
+                format!(
+                    "{}{}{}{}",
+                    base_type_definition, primary_definition, default_definition, unique_definition,
+                )
+            }
+            _ => {
+                format!(
+                    "{}{}{}{}{}",
+                    base_type_definition,
+                    primary_definition,
+                    default_definition,
+                    nullable_definition,
+                    unique_definition,
+                )
+            }
+        }
     }
 
     fn drop_column(name: &str) -> String {

--- a/src/backend/sqlite3.rs
+++ b/src/backend/sqlite3.rs
@@ -96,7 +96,7 @@ impl SqlGenerator for Sqlite {
             Custom(_) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
             Array(it) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(Array(Box::new(*it)))),
             Index(_) => unreachable!("Indices are handled via custom builder"),
-        Constraint(_, _) => unreachable!("Constraints are handled via custom builder"),
+            Constraint(_, _) => unreachable!("Constraints are handled via custom builder"),
         };
 
         match btc {

--- a/src/backend/sqlite3.rs
+++ b/src/backend/sqlite3.rs
@@ -92,7 +92,7 @@ impl SqlGenerator for Sqlite {
             Time => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
             DateTime => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
             Binary => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-            Foreign(_, _, _, _, _) => format!("{}\"{}\" INTEGER{}, REFERENCES {}", Sqlite::prefix(ex), name, nullable_definition, Sqlite::print_type(bt)),
+            Foreign(_, _, _, _, _) => format!("{}\"{}\" INTEGER{} REFERENCES {}", Sqlite::prefix(ex), name, nullable_definition, Sqlite::print_type(bt)),
             Custom(_) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
             Array(it) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(Array(Box::new(*it)))),
             Index(_) => unreachable!("Indices are handled via custom builder"),

--- a/src/backend/sqlite3.rs
+++ b/src/backend/sqlite3.rs
@@ -46,62 +46,87 @@ impl SqlGenerator for Sqlite {
 
     fn add_column(ex: bool, _: Option<&str>, name: &str, tt: &Type) -> String {
         let bt: BaseType = tt.get_inner();
+        let btc = bt.clone();
         use self::BaseType::*;
-
-        #[cfg_attr(rustfmt, rustfmt_skip)] /* This shouldn't be formatted. It's too long */
-        format!(
-            // SQL base - default - nullable - unique
-            "{}{}{}{}{}",
-            match bt {
-                Text => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                Varchar(_) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                Char(_) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                Primary => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                Integer => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                Serial => panic!("SQLite has no serials for non-primary key columns"),
-                Float => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                Double => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                UUID => panic!("`UUID` not supported by Sqlite3. Use `Text` instead!"),
-                Json => panic!("`Json` not supported by Sqlite3. Use `Text` instead!"),
-                Boolean => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                Date => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                Time => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                DateTime => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                Binary => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                Foreign(_, _, _, _, _) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                Custom(_) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
-                Array(it) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(Array(Box::new(*it)))),
-                Index(_) => unreachable!("Indices are handled via custom builder"),
-            Constraint(_, _) => unreachable!("Constraints are handled via custom builder"),
-            },
-            match tt.primary {
-                true => " PRIMARY KEY",
-                false => "",
-            },
-            match (&tt.default).as_ref() {
-                Some(ref m) => match m {
-                    WrappedDefault::Function(ref fun) => match fun {
-                        AutogenFunction::CurrentTimestamp => format!(" DEFAULT CURRENT_TIMESTAMP")
-                    }
-                    WrappedDefault::Null => format!(" DEFAULT NULL"),
-                    WrappedDefault::AnyText(ref val) => format!(" DEFAULT '{}'", val),
-                    WrappedDefault::UUID(ref val) => format!(" DEFAULT '{}'", val),
-                    WrappedDefault::Date(ref val) => format!(" DEFAULT '{:?}'", val),
-                    WrappedDefault::Boolean(val) => format!(" DEFAULT {}", if *val { 1 } else { 0 }),
-                    WrappedDefault::Custom(ref val) => format!(" DEFAULT '{}'", val),
-                    _ => format!(" DEFAULT {}", m)
+        let primary_definition = match tt.primary {
+            true => " PRIMARY KEY",
+            false => "",
+        };
+        let default_definition = match (&tt.default).as_ref() {
+            Some(ref m) => match m {
+                WrappedDefault::Function(ref fun) => match fun {
+                    AutogenFunction::CurrentTimestamp => format!(" DEFAULT CURRENT_TIMESTAMP"),
                 },
-                _ => format!(""),
+                WrappedDefault::Null => format!(" DEFAULT NULL"),
+                WrappedDefault::AnyText(ref val) => format!(" DEFAULT '{}'", val),
+                WrappedDefault::UUID(ref val) => format!(" DEFAULT '{}'", val),
+                WrappedDefault::Date(ref val) => format!(" DEFAULT '{:?}'", val),
+                WrappedDefault::Boolean(val) => format!(" DEFAULT {}", if *val { 1 } else { 0 }),
+                WrappedDefault::Custom(ref val) => format!(" DEFAULT '{}'", val),
+                _ => format!(" DEFAULT {}", m),
             },
-            match tt.nullable {
-                true => "",
-                false => " NOT NULL",
-            },
-            match tt.unique {
-                true => " UNIQUE",
-                false => "",
+            _ => format!(""),
+        };
+        let nullable_definition = match tt.nullable {
+            true => "",
+            false => " NOT NULL",
+        };
+        let unique_definition = match tt.unique {
+            true => " UNIQUE",
+            false => "",
+        };
+        #[cfg_attr(rustfmt, rustfmt_skip)] /* This shouldn't be formatted. It's too long */
+        let base_type_definition = match bt {
+            Text => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
+            Varchar(_) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
+            Char(_) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
+            Primary => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
+            Integer => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
+            Serial => panic!("SQLite has no serials for non-primary key columns"),
+            Float => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
+            Double => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
+            UUID => panic!("`UUID` not supported by Sqlite3. Use `Text` instead!"),
+            Json => panic!("`Json` not supported by Sqlite3. Use `Text` instead!"),
+            Boolean => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
+            Date => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
+            Time => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
+            DateTime => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
+            Binary => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
+            Foreign(_, _, _, _, _) => format!("{}\"{}\" INTEGER{}, REFERENCES {}", Sqlite::prefix(ex), name, nullable_definition, Sqlite::print_type(bt)),
+            Custom(_) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(bt)),
+            Array(it) => format!("{}\"{}\" {}", Sqlite::prefix(ex), name, Sqlite::print_type(Array(Box::new(*it)))),
+            Index(_) => unreachable!("Indices are handled via custom builder"),
+        Constraint(_, _) => unreachable!("Constraints are handled via custom builder"),
+        };
+
+        match btc {
+            Foreign(_, _, _, _, _) => {
+                format!(
+                    "{}{}{}{}",
+                    base_type_definition, primary_definition, default_definition, unique_definition,
+                )
             }
-        )
+            _ => {
+                format!(
+                    "{}{}{}{}{}",
+                    base_type_definition,
+                    primary_definition,
+                    default_definition,
+                    nullable_definition,
+                    unique_definition,
+                )
+            }
+        }
+        //#[cfg_attr(rustfmt, rustfmt_skip)] /* This shouldn't be formatted. It's too long */
+        //format!(
+        //    // SQL base - default - nullable - unique
+        //    "{}{}{}{}{}",
+        //    base_type_definition,
+        //    primary_definition,
+        //    default_definition,
+        //    nullable_definition,
+        //    unique_definition
+        //)
     }
 
     /// Create a multi-column index
@@ -224,7 +249,7 @@ impl Sqlite {
                     ReferentialAction::Unset => String::from(""),
                     _ => format!(" {}", on_update.on_update()),
                 };
-                format!("INTEGER REFERENCES {}({}){}{}", t, refs.0.join(","), u, d)
+                format!("{}({}){}{}", t, refs.0.join(","), u, d)
             }
             Custom(t) => format!("{}", t),
             Array(meh) => format!("{}[]", Sqlite::print_type(*meh)),

--- a/src/types/builders.rs
+++ b/src/types/builders.rs
@@ -1,7 +1,7 @@
 //! Builder API's module
 
 use super::impls::Constraint;
-use super::impls::{BaseType, WrapVec};
+use super::impls::{BaseType, ReferentialAction, WrapVec};
 use crate::types::Type;
 
 /// A standard primary numeric key type
@@ -82,18 +82,35 @@ pub fn binary<'inner>() -> Type {
 }
 
 /// Create a column that points to some foreign table
-pub fn foreign<S, I>(table: S, keys: I) -> Type
+pub fn foreign<S, I>(
+    table: S,
+    keys: I,
+    on_update: ReferentialAction,
+    on_delete: ReferentialAction,
+) -> Type
 where
     S: Into<String>,
     I: Into<WrapVec<String>>,
 {
-    Type::new(BaseType::Foreign(None, table.into(), keys.into()))
+    Type::new(BaseType::Foreign(
+        None,
+        table.into(),
+        keys.into(),
+        on_update,
+        on_delete,
+    ))
 }
 
 /// Like `foreign(...)` but letting you provide an external schema
 ///
 /// This function is important when making cross-schema references
-pub fn foreign_schema<S, I>(schema: S, table: S, keys: I) -> Type
+pub fn foreign_schema<S, I>(
+    schema: S,
+    table: S,
+    keys: I,
+    on_update: ReferentialAction,
+    on_delete: ReferentialAction,
+) -> Type
 where
     S: Into<String>,
     I: Into<WrapVec<String>>,
@@ -102,6 +119,8 @@ where
         Some(schema.into()),
         table.into(),
         keys.into(),
+        on_update,
+        on_delete,
     ))
 }
 

--- a/src/types/impls.rs
+++ b/src/types/impls.rs
@@ -55,7 +55,13 @@ pub enum BaseType {
     /// <inconceivable jibberish>
     Binary,
     /// Foreign key to other table
-    Foreign(Option<String>, String, WrapVec<String>),
+    Foreign(
+        Option<String>,
+        String,
+        WrapVec<String>,
+        ReferentialAction,
+        ReferentialAction,
+    ),
     /// I have no idea what you are – but I *like* it
     Custom(&'static str),
     /// Any of the above, but **many** of them
@@ -165,6 +171,43 @@ impl Type {
     /// Specify a size limit (important or varchar & similar)
     pub fn size(self, arg: usize) -> Self {
         Self { size: Some(arg), ..self }
+    }
+}
+
+/// Describes the referential_action for ON DELETE and ON UPDATE statements.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ReferentialAction {
+    Unset,
+    NoAction,
+    Restrict,
+    SetNull,
+    SetDefault,
+    Cascade,
+}
+
+impl ReferentialAction {
+    /// Returns the ON DELETE statement
+    pub fn on_delete(&self) -> String {
+        format!("ON DELETE {}", self)
+    }
+
+    /// Returns the ON UPDATE statement
+    pub fn on_update(&self) -> String {
+        format!("ON UPDATE {}", self)
+    }
+}
+
+impl std::fmt::Display for ReferentialAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Unset => panic!("The Unset variant cannot be displayed!"),
+            Self::NoAction => "NO ACTION",
+            Self::Restrict => "RESTRICT",
+            Self::SetNull => "SET NULL",
+            Self::SetDefault => "SET DEFAULT",
+            Self::Cascade => "CASCADE",
+        };
+        write!(f, "{}", s)
     }
 }
 

--- a/src/types/impls.rs
+++ b/src/types/impls.rs
@@ -98,7 +98,7 @@ pub enum BaseType {
 ///
 /// ## Examples
 ///
-/// ```rust,norun
+/// ```rust,no_run
 /// extern crate barrel;
 /// use barrel::types::*;
 ///

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -6,4 +6,4 @@ mod impls;
 pub use self::builders::*;
 
 pub use self::defaults::{null, WrappedDefault};
-pub use self::impls::{BaseType, Type, WrapVec};
+pub use self::impls::{BaseType, ReferentialAction, Type, WrapVec};


### PR DESCRIPTION
Hi there,

I added the possibility to add an ON UPDATE and ON DELETE statement for Pg, MySql and Sqlite3.
I do not know if this is in your sense of implementing this, because it adds two additional parameters to the API and therefore it is a breaking change. This solution was the cleanest one that I was able to find.
This would close #100 if you are happy with the solution, or tell me your approach so that I may change the implementation to it.

Greetings,
Lewin